### PR TITLE
fix(arrow/cdata): avoid unsafe.Slice on zero-length pointers

### DIFF
--- a/go/arrow/cdata/cdata.go
+++ b/go/arrow/cdata/cdata.go
@@ -359,10 +359,10 @@ func (imp *cimporter) importChild(parent *cimporter, src *CArrowArray) error {
 
 // import any child arrays for lists, structs, and so on.
 func (imp *cimporter) doImportChildren() error {
-	children := unsafe.Slice(imp.arr.children, imp.arr.n_children)
-
-	if len(children) > 0 {
-		imp.children = make([]cimporter, len(children))
+	var children []*CArrowArray
+	if imp.arr.n_children > 0 {
+		children = unsafe.Slice(imp.arr.children, imp.arr.n_children)
+		imp.children = make([]cimporter, imp.arr.n_children)
 	}
 
 	// handle the cases
@@ -701,10 +701,12 @@ func (imp *cimporter) importBinaryViewLike() (err error) {
 		return
 	}
 
-	dataBufferSizes := unsafe.Slice((*int64)(unsafe.Pointer(imp.cbuffers[len(buffers)])), len(buffers)-2)
-	for i, size := range dataBufferSizes {
-		if buffers[i+2], err = imp.importVariableValuesBuffer(i+2, 1, size); err != nil {
-			return
+	if len(buffers) > 2 {
+		dataBufferSizes := unsafe.Slice((*int64)(unsafe.Pointer(imp.cbuffers[len(buffers)])), len(buffers)-2)
+		for i, size := range dataBufferSizes {
+			if buffers[i+2], err = imp.importVariableValuesBuffer(i+2, 1, size); err != nil {
+				return
+			}
 		}
 	}
 
@@ -856,7 +858,7 @@ func (imp *cimporter) checkNumBuffers(n int64) error {
 func (imp *cimporter) importBuffer(bufferID int, sz int64) (*memory.Buffer, error) {
 	// this is not a copy, we're just having a slice which points at the data
 	// it's still owned by the C.ArrowArray object and its backing C++ object.
-	if imp.cbuffers[bufferID] == nil {
+	if imp.cbuffers[bufferID] == nil || sz == 0 {
 		if sz != 0 {
 			return nil, errors.New("invalid buffer")
 		}

--- a/go/arrow/cdata/cdata_test.go
+++ b/go/arrow/cdata/cdata_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/apache/arrow/go/v17/arrow/memory/mallocator"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSchemaExport(t *testing.T) {
@@ -708,6 +709,20 @@ func TestNestedArrays(t *testing.T) {
 			imported.Release()
 		})
 	}
+}
+
+func TestStrArrayAllNulls(t *testing.T) {
+	arr := exportStrArrayWithNulls(1000)
+	carr, err := ImportCArrayWithType(&arr, arrow.BinaryTypes.String)
+	require.NoError(t, err)
+	defer carr.Release()
+
+	buffer := carr.Data().Buffers()[2]
+	assert.NotNil(t, buffer)
+	bs := buffer.Bytes()
+	assert.Equal(t, 1000, carr.Len())
+	assert.Equal(t, 1000, carr.NullN())
+	assert.Empty(t, bs)
 }
 
 func TestRecordBatch(t *testing.T) {

--- a/go/arrow/cdata/cdata_test_framework.go
+++ b/go/arrow/cdata/cdata_test_framework.go
@@ -46,6 +46,7 @@ package cdata
 // }
 // void export_int32_type(struct ArrowSchema* schema);
 // void export_int32_array(const int32_t*, int64_t, struct ArrowArray*);
+// void export_str_array_with_nulls(int64_t nitems, struct ArrowArray* out);
 // int test1_is_released();
 // void test_primitive(struct ArrowSchema* schema, const char* fmt);
 // void free_malloced_schemas(struct ArrowSchema**);
@@ -93,6 +94,12 @@ func exportInt32TypeSchema() CArrowSchema {
 
 func releaseStream(s *CArrowArrayStream) {
 	C.ArrowArrayStreamRelease(s)
+}
+
+func exportStrArrayWithNulls(nitems int64) CArrowArray {
+	var arr CArrowArray
+	C.export_str_array_with_nulls(C.int64_t(nitems), &arr)
+	return arr
 }
 
 func schemaIsReleased(s *CArrowSchema) bool {


### PR DESCRIPTION
Backport apache/arrow-go#513 for Milvus issue https://github.com/milvus-io/milvus/issues/52233.

The C Data Interface permits an arbitrary pointer value for a zero-length buffer. Normalize such buffers before constructing a Go slice, and guard the other zero-length unsafe.Slice call sites in cdata.

This includes the upstream regression test for an all-null string array whose zero-length values buffer uses pointer 0x1.

Upstream commit: https://github.com/apache/arrow-go/commit/41441ea911bf4d54d27c918ff0061ed71dca8a39

Tests:
- go test -tags test ./arrow/cdata
- go test -tags test -run TestStrArrayAllNulls -count=100 ./arrow/cdata
- go test ./arrow/cdata